### PR TITLE
Update mojocoin.pro

### DIFF
--- a/mojocoin.pro
+++ b/mojocoin.pro
@@ -761,7 +761,7 @@ contains(RELEASE, 1) {
 
 !windows:!macx {
     DEFINES += LINUX
-    LIBS += -lrt -ldl
+    LIBS += -lrt -ldl -lgmp
 }
 
 system($$QMAKE_LRELEASE -silent $$_PRO_FILE_)


### PR DESCRIPTION
So the mojocoin-qt can be compiled on Linux without errors.